### PR TITLE
Add CRUD endpoints and DynamoDB backend

### DIFF
--- a/AgentApi.postman_collection.json
+++ b/AgentApi.postman_collection.json
@@ -1,0 +1,95 @@
+{
+  "info": {
+    "name": "Agent API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "List Agents",
+      "request": {
+        "method": "GET",
+        "header": [{"key": "Authorization", "value": "dummy-token"}],
+        "url": {
+          "raw": "{{base_url}}/agents",
+          "host": ["{{base_url}}"],
+          "path": ["agents"],
+          "query": []
+        }
+      }
+    },
+    {
+      "name": "Get Agent",
+      "request": {
+        "method": "GET",
+        "header": [{"key": "Authorization", "value": "dummy-token"}],
+        "url": {
+          "raw": "{{base_url}}/agents/{{id}}",
+          "host": ["{{base_url}}"],
+          "path": ["agents", "{{id}}"]
+        }
+      }
+    },
+    {
+      "name": "Create Agent",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Authorization", "value": "dummy-token"},
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"Example\",\n  \"category\": \"test\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/agents",
+          "host": ["{{base_url}}"],
+          "path": ["agents"]
+        }
+      }
+    },
+    {
+      "name": "Update Agent",
+      "request": {
+        "method": "PUT",
+        "header": [
+          {"key": "Authorization", "value": "dummy-token"},
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"description\": \"Updated\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/agents/{{id}}",
+          "host": ["{{base_url}}"],
+          "path": ["agents", "{{id}}"]
+        }
+      }
+    },
+    {
+      "name": "Delete Agent",
+      "request": {
+        "method": "DELETE",
+        "header": [{"key": "Authorization", "value": "dummy-token"}],
+        "url": {
+          "raw": "{{base_url}}/agents/{{id}}",
+          "host": ["{{base_url}}"],
+          "path": ["agents", "{{id}}"]
+        }
+      }
+    },
+    {
+      "name": "Run Agent",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Authorization", "value": "dummy-token"}],
+        "url": {
+          "raw": "{{base_url}}/agents/{{id}}/run",
+          "host": ["{{base_url}}"],
+          "path": ["agents", "{{id}}", "run"]
+        }
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agent API
 
-This repository contains a minimal serverless REST API built with AWS SAM. The
-API exposes two endpoints to list agents and retrieve a specific agent by id.
+This repository contains a small serverless REST API built with AWS SAM. The
+API now provides basic CRUD operations on agents stored in DynamoDB.
 A custom Lambda authorizer checks a dummy token before allowing access.
 
 ## Deployment
@@ -26,8 +26,14 @@ A custom Lambda authorizer checks a dummy token before allowing access.
 Send HTTP requests to the API endpoint using a tool like Postman. Include the
 header `Authorization: dummy-token` in each request.
 
-- `GET /agents` – list all agents
+Available endpoints:
+
+- `GET /agents` – list all agents (optional `?category=` filter)
 - `GET /agents/{id}` – retrieve a single agent
+- `POST /agents` – create a new agent
+- `PUT /agents/{id}` – update an existing agent
+- `DELETE /agents/{id}` – delete an agent
+- `POST /agents/{id}/run` – run an agent (placeholder)
 
 Example using `curl`:
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,87 @@
+import json
+import os
+import uuid
+from datetime import datetime
+import boto3
+from boto3.dynamodb.conditions import Key
+
+dynamodb = boto3.resource("dynamodb")
+table = dynamodb.Table(os.environ["AGENTS_TABLE"])
+
+def response(status, body):
+    return {
+        "statusCode": status,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+def lambda_handler(event, context):
+    http_method = event.get("httpMethod")
+    resource = event.get("resource")
+    if resource == "/agents" and http_method == "GET":
+        return list_agents(event)
+    if resource == "/agents/{id}" and http_method == "GET":
+        return get_agent(event)
+    if resource == "/agents" and http_method == "POST":
+        return create_agent(event)
+    if resource == "/agents/{id}" and http_method == "PUT":
+        return update_agent(event)
+    if resource == "/agents/{id}" and http_method == "DELETE":
+        return delete_agent(event)
+    if resource == "/agents/{id}/run" and http_method == "POST":
+        return run_agent(event)
+    return response(404, {"message": "Not found"})
+
+def list_agents(event):
+    params = event.get("queryStringParameters") or {}
+    category = params.get("category") if params else None
+    if category:
+        result = table.query(
+            IndexName="CategoryIndex",
+            KeyConditionExpression=Key("category").eq(category),
+        )
+        items = result.get("Items", [])
+    else:
+        result = table.scan()
+        items = result.get("Items", [])
+    return response(200, items)
+
+def get_agent(event):
+    agent_id = event["pathParameters"]["id"]
+    result = table.get_item(Key={"id": agent_id})
+    item = result.get("Item")
+    if not item:
+        return response(404, {"message": "Agent not found"})
+    return response(200, item)
+
+def create_agent(event):
+    data = json.loads(event.get("body") or "{}")
+    agent_id = data.get("id", str(uuid.uuid4()))
+    now = datetime.utcnow().isoformat()
+    item = {**data, "id": agent_id, "createdAt": now, "updatedAt": now}
+    table.put_item(Item=item)
+    return response(201, item)
+
+def update_agent(event):
+    agent_id = event["pathParameters"]["id"]
+    result = table.get_item(Key={"id": agent_id})
+    existing = result.get("Item")
+    if not existing:
+        return response(404, {"message": "Agent not found"})
+    data = json.loads(event.get("body") or "{}")
+    now = datetime.utcnow().isoformat()
+    item = {**existing, **data, "id": agent_id, "updatedAt": now}
+    if "createdAt" not in item:
+        item["createdAt"] = now
+    table.put_item(Item=item)
+    return response(200, item)
+
+def delete_agent(event):
+    agent_id = event["pathParameters"]["id"]
+    table.delete_item(Key={"id": agent_id})
+    return response(204, {})
+
+def run_agent(event):
+    agent_id = event["pathParameters"]["id"]
+    # Placeholder for actual execution logic
+    return response(202, {"message": f"Agent {agent_id} execution started"})

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,22 @@
+import os
+
+def lambda_handler(event, context):
+    token = event.get("headers", {}).get("Authorization", "")
+    method_arn = event.get("methodArn")
+    if token == os.environ.get("DUMMY_TOKEN", "dummy-token"):
+        effect = "Allow"
+    else:
+        effect = "Deny"
+    return {
+        "principalId": "user",
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": effect,
+                    "Resource": method_arn,
+                }
+            ],
+        },
+    }

--- a/template.yaml
+++ b/template.yaml
@@ -22,6 +22,12 @@ Resources:
       CodeUri: .
       Handler: src/app.lambda_handler
       Runtime: python3.13
+      Environment:
+        Variables:
+          AGENTS_TABLE: !Ref AgentsTable
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref AgentsTable
       Events:
         ListAgents:
           Type: Api
@@ -35,6 +41,30 @@ Resources:
             Path: /agents/{id}
             Method: GET
             RestApiId: !Ref AgentApi
+        CreateAgent:
+          Type: Api
+          Properties:
+            Path: /agents
+            Method: POST
+            RestApiId: !Ref AgentApi
+        UpdateAgent:
+          Type: Api
+          Properties:
+            Path: /agents/{id}
+            Method: PUT
+            RestApiId: !Ref AgentApi
+        DeleteAgent:
+          Type: Api
+          Properties:
+            Path: /agents/{id}
+            Method: DELETE
+            RestApiId: !Ref AgentApi
+        RunAgent:
+          Type: Api
+          Properties:
+            Path: /agents/{id}/run
+            Method: POST
+            RestApiId: !Ref AgentApi
 
   DummyAuthorizerFunction:
     Type: AWS::Serverless::Function
@@ -45,6 +75,26 @@ Resources:
       Environment:
         Variables:
           DUMMY_TOKEN: dummy-token
+
+  AgentsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+        - AttributeName: category
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: CategoryIndex
+          KeySchema:
+            - AttributeName: category
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
 
 Outputs:
   ApiUrl:


### PR DESCRIPTION
## Summary
- implement Lambda functions for agent CRUD endpoints
- create Postman collection for new routes
- expand README usage instructions
- update SAM template with DynamoDB table and new API routes

## Testing
- `python3 -m py_compile src/app.py src/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_685658eb8dac832a96e64e33c5d2a348