### PR TITLE
Update Postman headers and README

### DIFF
--- a/AgentApi.postman_collection.json
+++ b/AgentApi.postman_collection.json
@@ -8,7 +8,7 @@
       "name": "List Agents",
       "request": {
         "method": "GET",
-        "header": [{"key": "Authorization", "value": "dummy-token"}],
+        "header": [{"key": "Authorization", "value": "Bearer {{jwt_token}}"}],
         "url": {
           "raw": "{{base_url}}/agents",
           "host": ["{{base_url}}"],
@@ -21,7 +21,7 @@
       "name": "Get Agent",
       "request": {
         "method": "GET",
-        "header": [{"key": "Authorization", "value": "dummy-token"}],
+        "header": [{"key": "Authorization", "value": "Bearer {{jwt_token}}"}],
         "url": {
           "raw": "{{base_url}}/agents/{{id}}",
           "host": ["{{base_url}}"],
@@ -34,7 +34,7 @@
       "request": {
         "method": "POST",
         "header": [
-          {"key": "Authorization", "value": "dummy-token"},
+          {"key": "Authorization", "value": "Bearer {{jwt_token}}"},
           {"key": "Content-Type", "value": "application/json"}
         ],
         "body": {
@@ -53,7 +53,7 @@
       "request": {
         "method": "PUT",
         "header": [
-          {"key": "Authorization", "value": "dummy-token"},
+          {"key": "Authorization", "value": "Bearer {{jwt_token}}"},
           {"key": "Content-Type", "value": "application/json"}
         ],
         "body": {
@@ -71,7 +71,7 @@
       "name": "Delete Agent",
       "request": {
         "method": "DELETE",
-        "header": [{"key": "Authorization", "value": "dummy-token"}],
+        "header": [{"key": "Authorization", "value": "Bearer {{jwt_token}}"}],
         "url": {
           "raw": "{{base_url}}/agents/{{id}}",
           "host": ["{{base_url}}"],
@@ -83,7 +83,7 @@
       "name": "Run Agent",
       "request": {
         "method": "POST",
-        "header": [{"key": "Authorization", "value": "dummy-token"}],
+        "header": [{"key": "Authorization", "value": "Bearer {{jwt_token}}"}],
         "url": {
           "raw": "{{base_url}}/agents/{{id}}/run",
           "host": ["{{base_url}}"],

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ sam local start-api
 Then issue requests to `http://127.0.0.1:3000/agents` with a valid JWT token in
 the `Authorization` header.
 
+## Postman Collection
+
+The repository includes `AgentApi.postman_collection.json`. Import this file
+into Postman and create an environment with the following variables:
+
+- `base_url` – the deployed API endpoint
+- `jwt_token` – a valid Cognito access token
+
+Select the environment before sending requests. The collection can also be run
+from the command line using [newman](https://github.com/postmanlabs/newman).
+
 ## Project Structure
 
 - `src/app.py` – Lambda handler for the API


### PR DESCRIPTION
## Summary
- update Postman collection to use `Bearer {{jwt_token}}`
- document Postman environment variables and newman usage in README

## Testing
- `python -m py_compile src/app.py src/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6856c43c3940832aa5c6e96965a6312f